### PR TITLE
mcuboot: Remove parameter for SYS_INIT function

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -695,10 +695,8 @@ void main(void)
 }
 
 #ifdef CONFIG_IMCU_IPC
-static int imcu_ipc_init(const struct device *dev)
+static int imcu_ipc_init(void)
 {
-    ARG_UNUSED(dev);
-
     imcu_ipc_client_init();
 
     return 0;


### PR DESCRIPTION
This is needed when upgrading to NCS v2.4.0 due to changes from zephyr.